### PR TITLE
🔖 Mise à jour vers Minecraft 26.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         # Use these Java versions
         java: [
-          21,    # Current Java LTS
+          25,    # Current Java LTS
         ]
     runs-on: ubuntu-24.04
     steps:
@@ -30,7 +30,7 @@ jobs:
       - name: build
         run: ./gradlew build --stacktrace -x runGameTest -x acceptGameTestEula
       - name: capture build artifacts
-        if: ${{ matrix.java == '21' }} # Only upload artifacts built from latest java
+        if: ${{ matrix.java == '25' }} # Only upload artifacts built from latest java
         uses: actions/upload-artifact@v4
         with:
           name: Artifacts
@@ -41,10 +41,10 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
-      - name: setup jdk 21
+      - name: setup jdk 25
         uses: actions/setup-java@v4
         with:
-          java-version: "21"
+          java-version: "25"
           distribution: "microsoft"
       - name: make gradle wrapper executable
         run: chmod +x ./gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.13.3'
+	id 'net.fabricmc.fabric-loom' version "${loom_version}"
 	id 'maven-publish'
 }
 
@@ -32,11 +32,10 @@ loom {
 dependencies {
 	// To change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	implementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
 	
 }
 
@@ -61,7 +60,7 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	it.options.release = 21
+	it.options.release = 25
 }
 
 java {
@@ -70,8 +69,8 @@ java {
 	// If you remove this line, sources will not be generated.
 	withSourcesJar()
 
-	sourceCompatibility = JavaVersion.VERSION_21
-	targetCompatibility = JavaVersion.VERSION_21
+	sourceCompatibility = JavaVersion.VERSION_25
+	targetCompatibility = JavaVersion.VERSION_25
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,5 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
-org.gradle.java.home=/Library/Java/JavaVirtualMachines/jdk-25.jdk/Contents/Home
 org.gradle.parallel=true
 
 # Fabric Properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,17 +1,18 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
+org.gradle.java.home=/Library/Java/JavaVirtualMachines/jdk-25.jdk/Contents/Home
 org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.11
-yarn_mappings=1.21.11+build.4
-loader_version=0.18.5
+minecraft_version=26.1
+loader_version=0.19.3
+loom_version=1.17-SNAPSHOT
 
 # Mod Properties
-mod_version=1.2.0+1.21.11
+mod_version=1.2.0+26.1
 maven_group=net.minecraftfr.helmetoverlay
 archives_base_name=helmet-overlay
 
 # Dependencies
-fabric_version=0.141.3+1.21.11
+fabric_api_version=0.145.1+26.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/client/java/net/minecraftfr/helmetoverlay/mixin/client/InGameHudMixin.java
+++ b/src/client/java/net/minecraftfr/helmetoverlay/mixin/client/InGameHudMixin.java
@@ -7,29 +7,29 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gl.RenderPipelines;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.hud.InGameHud;
-import net.minecraft.client.network.ClientPlayerEntity;
-import net.minecraft.client.render.RenderTickCounter;
-import net.minecraft.entity.EquipmentSlot;
-import net.minecraft.item.ItemStack;
-import net.minecraft.registry.Registries;
-import net.minecraft.resource.Resource;
-import net.minecraft.resource.ResourceManager;
-import net.minecraft.util.Identifier;
+import net.minecraft.client.DeltaTracker;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Gui;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.client.renderer.RenderPipelines;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.packs.resources.Resource;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.item.ItemStack;
 
-@Mixin(InGameHud.class)
+@Mixin(Gui.class)
 public class InGameHudMixin {
-  @Inject(method = "renderMiscOverlays", at = @At("HEAD"))
-  public void renderMiscOverlays(DrawContext context, RenderTickCounter tickCounter, CallbackInfo ci) {
-    MinecraftClient client = MinecraftClient.getInstance();
+  @Inject(method = "extractRenderState", at = @At("HEAD"))
+  public void extractRenderState(GuiGraphicsExtractor context, DeltaTracker tickCounter, CallbackInfo ci) {
+    Minecraft client = Minecraft.getInstance();
 
-    if (client != null && client.player != null && client.options.getPerspective().isFirstPerson()) {
+    if (client != null && client.player != null && client.options.getCameraType().isFirstPerson()) {
       ItemStack helmet = getHelmetFromPlayer(client.player);
       if (!helmet.isEmpty()) {
-        Identifier identifier = getHelmeIdentifier(helmet);
+        Identifier identifier = getHelmetIdentifier(helmet);
 
         if (resourceExists(identifier)) {
           renderOverlay(context, identifier, 1.0F);
@@ -38,20 +38,18 @@ public class InGameHudMixin {
     }
   }
 
-  private ItemStack getHelmetFromPlayer(ClientPlayerEntity player) {
-    return player.getEquippedStack(EquipmentSlot.HEAD);
+  private ItemStack getHelmetFromPlayer(LocalPlayer player) {
+    return player.getItemBySlot(EquipmentSlot.HEAD);
   }
 
-  private Identifier getHelmeIdentifier(ItemStack helmet) {
-    String helmet_texture_name = Registries.ITEM.getId(helmet.getItem()).getPath();
+  private Identifier getHelmetIdentifier(ItemStack helmet) {
+    String helmet_texture_name = BuiltInRegistries.ITEM.getKey(helmet.getItem()).getPath();
     String texture_path = "textures/misc/" + helmet_texture_name + "_overlay.png";
-    Identifier identifier = Identifier.ofVanilla(texture_path);
-
-    return identifier;
+    return Identifier.withDefaultNamespace(texture_path);
   }
 
   private boolean resourceExists(Identifier identifier) {
-    ResourceManager resourceManager = MinecraftClient.getInstance().getResourceManager();
+    ResourceManager resourceManager = Minecraft.getInstance().getResourceManager();
     try {
       Optional<Resource> resource = resourceManager.getResource(identifier);
       return resource.isPresent();
@@ -60,11 +58,11 @@ public class InGameHudMixin {
     }
   }
 
-  private void renderOverlay(DrawContext context, Identifier texture, float opacity) {
-    int width = context.getScaledWindowWidth();
-    int height = context.getScaledWindowHeight();
+  private void renderOverlay(GuiGraphicsExtractor context, Identifier texture, float opacity) {
+    int width = context.guiWidth();
+    int height = context.guiHeight();
     int alpha = Math.min(255, Math.max(0, (int) (opacity * 255.0F)));
     int color = (alpha << 24) | 0xFFFFFF;
-    context.drawTexture(RenderPipelines.GUI_TEXTURED, texture, 0, 0, 0.0F, 0.0F, width, height, width, height, color);
+    context.blit(RenderPipelines.GUI_TEXTURED, texture, 0, 0, 0.0F, 0.0F, width, height, width, height, color);
   }
 }

--- a/src/gametest/java/net/minecraftfr/helmetoverlay/gametest/HelmetOverlayClientGameTest.java
+++ b/src/gametest/java/net/minecraftfr/helmetoverlay/gametest/HelmetOverlayClientGameTest.java
@@ -3,8 +3,8 @@ package net.minecraftfr.helmetoverlay.gametest;
 import net.fabricmc.fabric.api.client.gametest.v1.FabricClientGameTest;
 import net.fabricmc.fabric.api.client.gametest.v1.context.ClientGameTestContext;
 import net.fabricmc.fabric.api.client.gametest.v1.context.TestSingleplayerContext;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.option.Perspective;
+import net.minecraft.client.CameraType;
+import net.minecraft.client.Minecraft;
 
 @SuppressWarnings("UnstableApiUsage")
 public class HelmetOverlayClientGameTest implements FabricClientGameTest {
@@ -16,17 +16,17 @@ public class HelmetOverlayClientGameTest implements FabricClientGameTest {
 		context.getInput().resizeWindow(VIEWPORT_WIDTH, VIEWPORT_HEIGHT);
 
 		try (TestSingleplayerContext sp = context.worldBuilder().create()) {
-			sp.getClientWorld().waitForChunksDownload();
-			sp.getClientWorld().waitForChunksRender();
+			sp.getClientLevel().waitForChunksDownload();
+			sp.getClientLevel().waitForChunksRender();
 
 			sp.getServer().runCommand("item replace entity @p armor.head with minecraft:iron_helmet");
 
-			context.runOnClient((MinecraftClient client) -> {
-				client.options.setPerspective(Perspective.FIRST_PERSON);
+			context.runOnClient((Minecraft client) -> {
+				client.options.setCameraType(CameraType.FIRST_PERSON);
 			});
 
 			context.waitTicks(20);
-			sp.getClientWorld().waitForChunksRender();
+			sp.getClientLevel().waitForChunksRender();
 
 			context.assertScreenshotEquals("iron_helmet_overlay");
 		}

--- a/src/gametest/resources/fabric.mod.json
+++ b/src/gametest/resources/fabric.mod.json
@@ -11,8 +11,8 @@
 	},
 	"depends": {
 		"fabricloader": ">=0.16.14",
-		"minecraft": "~1.21.11",
-		"java": ">=21",
+		"minecraft": "~26.1",
+		"java": ">=25",
 		"fabric-api": "*",
 		"helmet-overlay": "*"
 	}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,8 +28,8 @@
 	],
 	"depends": {
 		"fabricloader": ">=0.16.14",
-		"minecraft": "~1.21.11",
-		"java": ">=21",
+		"minecraft": "~26.1",
+		"java": ">=25",
 		"fabric-api": "*"
 	},
 	"suggests": {


### PR DESCRIPTION
## Résumé

- Migration de Minecraft 1.21.11 vers **26.1**
- Loom 1.13.3 → **1.17-SNAPSHOT** (nouveau plugin ID `net.fabricmc.fabric-loom`)
- Gradle 8.14 → **9.5.0** (requis par Loom 1.17)
- Java 21 → **25** (requis par Minecraft 26.1)

## Changements notables

### Build
- Minecraft 26.1 n'a ni Yarn mappings ni Mojang mappings publiés → la ligne `mappings` est supprimée (Loom 1.17 gère les mappings en interne)
- `modImplementation` → `implementation` pour `fabric-loader` et `fabric-api` (nouveau comportement Loom 1.17)
- `fabric_version` → `fabric_api_version` dans `gradle.properties`

### Code (noms Mojang au lieu de Yarn)
| Ancien (Yarn) | Nouveau (Mojang) |
|---|---|
| `InGameHud` | `Gui` |
| `DrawContext` | `GuiGraphicsExtractor` |
| `renderMiscOverlays` | `extractRenderState` |
| `MinecraftClient` | `Minecraft` |
| `RenderTickCounter` | `DeltaTracker` |
| `Registries.ITEM.getId` | `BuiltInRegistries.ITEM.getKey` |
| `Identifier.ofVanilla` | `Identifier.withDefaultNamespace` |
| `getEquippedStack` | `getItemBySlot` |
| `options.getPerspective` | `options.getCameraType` |

### Gametest
- `getClientWorld()` → `getClientLevel()`
- `Perspective.FIRST_PERSON` → `CameraType.FIRST_PERSON`
- `setPerspective` → `setCameraType`

## Plan de test

- [x] `./gradlew compileJava compileClientJava compileGametestJava` → BUILD SUCCESSFUL
- [x] `./gradlew test` → BUILD SUCCESSFUL
- [x] `./gradlew runGameTest` → BUILD SUCCESSFUL
- [x] `./gradlew runClientGameTest` → BUILD SUCCESSFUL