### PR TITLE
🔖 Mettre à jour vers Minecraft 26.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,10 @@ java {
 	// If you remove this line, sources will not be generated.
 	withSourcesJar()
 
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(25)
+	}
+
 	sourceCompatibility = JavaVersion.VERSION_25
 	targetCompatibility = JavaVersion.VERSION_25
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,14 +4,14 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=26.1
+minecraft_version=26.2
 loader_version=0.19.3
 loom_version=1.17-SNAPSHOT
 
 # Mod Properties
-mod_version=1.2.1+26.1
+mod_version=1.2.1+26.2
 maven_group=net.minecraftfr.helmetoverlay
 archives_base_name=helmet-overlay
 
 # Dependencies
-fabric_api_version=0.145.1+26.1
+fabric_api_version=0.152.1+26.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/client/java/net/minecraftfr/helmetoverlay/mixin/client/InGameHudMixin.java
+++ b/src/client/java/net/minecraftfr/helmetoverlay/mixin/client/InGameHudMixin.java
@@ -9,7 +9,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.Gui;
+import net.minecraft.client.gui.Hud;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.client.renderer.RenderPipelines;
@@ -20,7 +20,7 @@ import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.ItemStack;
 
-@Mixin(Gui.class)
+@Mixin(Hud.class)
 public class InGameHudMixin {
   @Inject(method = "extractRenderState", at = @At("HEAD"))
   public void extractRenderState(GuiGraphicsExtractor context, DeltaTracker tickCounter, CallbackInfo ci) {

--- a/src/gametest/resources/fabric.mod.json
+++ b/src/gametest/resources/fabric.mod.json
@@ -11,7 +11,7 @@
 	},
 	"depends": {
 		"fabricloader": ">=0.16.14",
-		"minecraft": "~26.1",
+		"minecraft": "~26.2",
 		"java": ">=25",
 		"fabric-api": "*",
 		"helmet-overlay": "*"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,7 +28,7 @@
 	],
 	"depends": {
 		"fabricloader": ">=0.16.14",
-		"minecraft": "~26.1",
+		"minecraft": "~26.2",
 		"java": ">=25",
 		"fabric-api": "*"
 	},


### PR DESCRIPTION
## Résumé

Mise à jour du mod vers Minecraft 26.2 avec Fabric API 0.152.1.

## Changements

- `minecraft_version` → `26.2`
- `fabric_api_version` → `0.152.1+26.2`
- `mod_version` → `1.2.1+26.2`
- Gradle wrapper → 9.5.1 (requis par la migration 26.2)
- Contrainte `"minecraft": "~26.2"` dans les deux `fabric.mod.json`

## Corrections nécessaires

**Toolchain Java 25 explicite dans `build.gradle`** : Loom sélectionnait automatiquement JDK 21 au lieu de 25, provoquant une erreur `release version 25 not supported` à la compilation. Ajout d'un bloc `toolchain { languageVersion = JavaLanguageVersion.of(25) }` pour forcer le bon JDK.

**Mixin `InGameHudMixin`** : Dans MC 26.2, `extractRenderState(GuiGraphicsExtractor, DeltaTracker)` a été déplacée de `Gui` vers `Hud`. Le mixin cible désormais `@Mixin(Hud.class)` au lieu de `@Mixin(Gui.class)`.

## Tests

- `./gradlew test` ✅
- `./gradlew runGameTest` ✅
- `./gradlew runClientGameTest` ✅